### PR TITLE
[#17] Remove redcarpet dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'compass'
-gem 'redcarpet'
 gem 'rouge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.3)
+    jekyll (3.8.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -58,7 +58,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    redcarpet (3.4.0)
     rouge (3.2.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
@@ -70,8 +69,7 @@ PLATFORMS
 DEPENDENCIES
   compass
   jekyll
-  redcarpet
   rouge
 
 BUNDLED WITH
-   1.16.3
+   1.16.5

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 name: Belfast Ruby
-markdown: redcarpet
 highlighter: rouge
 baseurl :
 


### PR DESCRIPTION
What's changed? 
Removal of _redcarpet_ gem from gemfile and config.yml as discussed in #17
Updated gemfile lock
Bumped jekyll version